### PR TITLE
NCBC-3304: ObjectDisposedException on GET command during rebalance

### DIFF
--- a/src/Couchbase/Core/Exceptions/KeyValue/SocketNotAvailableException.cs
+++ b/src/Couchbase/Core/Exceptions/KeyValue/SocketNotAvailableException.cs
@@ -1,20 +1,14 @@
-namespace Couchbase.Core.Retry
-{
-    public static class RetryReasonExtensions
-    {
-        public static bool AllowsNonIdempotentRetries(this RetryReason reason)
-        {
-            return !(reason == RetryReason.Unknown || reason == RetryReason.SocketClosedWhileInFlight);
-        }
+using Couchbase.Core.Retry;
 
-        public static bool AlwaysRetry(this RetryReason reason)
+namespace Couchbase.Core.Exceptions.KeyValue
+{
+    /// <summary>
+    /// Thrown when a socket is temporarily unavailable. This exception is caught and will force a retry.
+    /// </summary>
+    public class SocketNotAvailableException : KeyValueException, IRetryable
+    {
+        public SocketNotAvailableException(string message) : base(message)
         {
-            return reason == RetryReason.KvNotMyVBucket ||
-                   reason == RetryReason.ScopeNotFound ||
-                   reason == RetryReason.CollectionNotFound ||
-                   reason == RetryReason.ViewsNoActivePartition ||
-                   reason == RetryReason.CircuitBreakerOpen ||
-                   reason == RetryReason.SocketNotAvailable;
         }
     }
 }

--- a/src/Couchbase/Core/IO/Connections/Channels/ChannelConnectionPool.cs
+++ b/src/Couchbase/Core/IO/Connections/Channels/ChannelConnectionPool.cs
@@ -191,7 +191,8 @@ namespace Couchbase.Core.IO.Connections.Channels
         {
             if (_cts.IsCancellationRequested)
             {
-                ThrowHelper.ThrowObjectDisposedException(nameof(ChannelConnectionPool));
+                //Were not throwing an ODE because we want a more specific exception that reuse the retry logic in the RetryOrchestrator
+                ThrowHelper.ThrowSocketNotAvailableException(nameof(ChannelConnectionPool));
             }
         }
 

--- a/src/Couchbase/Core/IO/Connections/DataFlow/DataFlowConnectionPool.cs
+++ b/src/Couchbase/Core/IO/Connections/DataFlow/DataFlowConnectionPool.cs
@@ -223,7 +223,8 @@ namespace Couchbase.Core.IO.Connections.DataFlow
         {
             if (_cts.IsCancellationRequested)
             {
-                ThrowHelper.ThrowObjectDisposedException(nameof(DataFlowConnectionPool));
+                //Were not throwing an ODE because we want a more specific exception that reuse the retry logic in the RetryOrchestrator
+                ThrowHelper.ThrowSocketNotAvailableException(nameof(DataFlowConnectionPool));
             }
         }
 

--- a/src/Couchbase/Core/Retry/ExceptionExtensions.cs
+++ b/src/Couchbase/Core/Retry/ExceptionExtensions.cs
@@ -29,6 +29,8 @@ namespace Couchbase.Core.Retry
                 case CircuitBreakerException _: return RetryReason.CircuitBreakerOpen;
                 case CollectionNotFoundException _: return RetryReason.CollectionNotFound;
                 case ScopeNotFoundException _: return RetryReason.ScopeNotFound;
+                case SocketNotAvailableException _: return RetryReason.SocketNotAvailable;
+                //case ServiceResponseRetryException _: return RetryReason.ServiceResponseCodeIndicated;
                 default:
                 {
                     return RetryReason.NoRetry;

--- a/src/Couchbase/Utils/ThrowHelper.cs
+++ b/src/Couchbase/Utils/ThrowHelper.cs
@@ -59,6 +59,10 @@ namespace Couchbase.Utils
             throw new ObjectDisposedException(objectName);
 
         [DoesNotReturn]
+        public static void ThrowSocketNotAvailableException(string objectName) =>
+            throw new SocketNotAvailableException(objectName);
+
+        [DoesNotReturn]
         public static void ThrowOperationCanceledException() =>
             throw new OperationCanceledException();
 

--- a/tests/Couchbase.UnitTests/Core/IO/Connections/Channels/ChannelConnectionPoolTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Connections/Channels/ChannelConnectionPoolTests.cs
@@ -18,8 +18,7 @@ using Xunit.Abstractions;
 namespace Couchbase.UnitTests.Core.IO.Connections.Channels
 {
 #pragma warning disable xUnit1000 // Test classes must be public
-    /*public*/
-    class ChannelConnectionPoolTests
+    public class ChannelConnectionPoolTests
 #pragma warning restore xUnit1000 // Test classes must be public
     {
         private readonly ITestOutputHelper _testOutput;
@@ -161,7 +160,7 @@ namespace Couchbase.UnitTests.Core.IO.Connections.Channels
             var operations = Enumerable.Range(1, toSendCount)
                 .Select(_ => new FakeOperation
                 {
-                    Delay = TimeSpan.FromMilliseconds(1000),
+                    Delay = TimeSpan.FromMilliseconds(100),
                     SendStarted = SendStarted,
                     SendComplete = SendCompleted
                 })
@@ -269,6 +268,11 @@ namespace Couchbase.UnitTests.Core.IO.Connections.Channels
         #endregion
 
         #region Dispose
+
+        public async Task Disposed_Connection_Throws_ODE()
+        {
+
+        }
 
         [Fact]
         public async Task Dispose_ClosesAllConnections()


### PR DESCRIPTION
Motivation
----------
Forces an operation to be retried if an ODE is thrown instead of letting the exception been thrown and handled by the application.

Modification
------------
 - Add SocketNotAvailableException and use in place of ODE
 - Take advantage of the fact that SNAE implements IRetriable and will force a retry.
 - Add mapping of ResponseStatus to RetryReasons

wwwwww

Change-Id: I8ae622ac63d6c4c2ec1424367ae9bed8c3b09132
Reviewed-on: https://review.couchbase.org/c/couchbase-net-client/+/183548
Tested-by: Build Bot <build@couchbase.com>
Reviewed-by: Richard Ponton <richard.ponton@couchbase.com>